### PR TITLE
link-hint--collect-visible-links: Fix redisplay-related bug

### DIFF
--- a/link-hint.el
+++ b/link-hint.el
@@ -899,7 +899,7 @@ Only search the range between just after the point and BOUND."
   "Collect all visible links in the current buffer."
   (let (all-link-positions)
     (dolist (bounds (link-hint--find-visible-regions (window-start)
-                                                     (window-end)))
+                                                     (window-end nil t)))
       (dolist (type link-hint-types)
         (when (link-hint--type-valid-p type)
           (setq all-link-positions

--- a/link-hint.el
+++ b/link-hint.el
@@ -253,7 +253,7 @@ link-hint-NAME."
 (defun link-hint--var-valid-p (var)
   "Return t if VAR is bound and true or is the current major mode."
   (or (eq var major-mode)
-      (and (boundp var) (symbol-value var))))
+      (bound-and-true-p var)))
 
 (defun link-hint--type-valid-p (type)
   "Return whether TYPE is a valid type for the current buffer.


### PR DESCRIPTION
Without the UPDATE argument, `window-end' return value is wrong (and
can cause part of the links being missed) e.g. when calling hint-link
from a transient multiline completion window (which closes before the
hints are generated).

---

I don't know if some of the other window-end calls might need fixing,
too; my cursory experience seems to indicate that at least some of
them do not.