### PR TITLE
link-hint--apply: Attempt to improve the condition-case madness

### DIFF
--- a/link-hint.el
+++ b/link-hint.el
@@ -972,12 +972,9 @@ First try `apply'. If there is an error (ARGS is the wrong number of arguments
 for FUNC), `funcall' FUNC with ARGS. Finally, call FUNC alone."
   (when parser
     (setq args (funcall parser args action)))
-  ;; TODO is there a way to know how many arguments a function takes?
   (condition-case nil
-      (apply func args)
-    (error (condition-case nil
-               (funcall func args)
-             (error (funcall func))))))
+      (apply func (if (listp args) args (list args)))
+    (wrong-number-of-arguments (funcall func))))
 
 (defun link-hint--message (action &optional link-description type)
   "Display a message about an ACTION performed on a link.


### PR DESCRIPTION
There is `func-arity' (since Emacs 26.1; there was only `subr-arity'
before that), but instead of trying to parse and deal with all
possible arity implications, simplify the logic to the following:

- if ARGS is a list, leave it alone and use `apply'
- if it is a non-list, wrap it in a list and use `apply'
- instead of catching all errors and breaking in all kinds of
  unexpected ways (e.g. when FUNC signals an unrelated but
  legitimate error), handle only `wrong-number-of-arguments', for
  cases where FUNC doesn't want any