### PR TITLE
Fix obsoleted warning

### DIFF
--- a/link-hint.el
+++ b/link-hint.el
@@ -954,7 +954,7 @@ return it."
             (not avy-single-candidate-jump))
         (save-selected-window
           (let* ((avy-action #'identity)
-                 (pos (avy--process
+                 (pos (avy-process
                        (mapcar (lambda (x) (cons (plist-get x :pos)
                                                  (plist-get x :win)))
                                links)


### PR DESCRIPTION
```
link-hint.el:957:24:Warning: ‘avy--process’ is an obsolete function (as of
    0.4.0); use ‘avy-process’ instead.
```