### PR TITLE
Support org link minor mode

### DIFF
--- a/link-hint.el
+++ b/link-hint.el
@@ -254,7 +254,8 @@ link-hint-NAME."
 (defun link-hint--var-valid-p (var)
   "Return t if VAR is bound and true or is the current major mode."
   (or (eq var major-mode)
-      (bound-and-true-p var)))
+      (and (boundp var)
+           (symbol-value var))))
 
 (defun link-hint--type-valid-p (type)
   "Return whether TYPE is a valid type for the current buffer.

--- a/link-hint.el
+++ b/link-hint.el
@@ -416,7 +416,7 @@ Only search the range between just after the point and BOUND."
 (link-hint-define-type 'org-link
   :next #'link-hint--next-org-link
   :at-point-p #'link-hint--org-link-at-point-p
-  :vars '(org-mode)
+  :vars '(org-mode org-link-minor-mode)
   :open #'link-hint--open-org-link
   :open-multiple t
   :copy #'kill-new)


### PR DESCRIPTION
closes #26 

Fixes a bug that didn't allow minor-mode links to work and adds support for `org-link-minor-mode`.