### PR TITLE
Autoload link-hint-copy-link-at-point

### DIFF
--- a/link-hint.el
+++ b/link-hint.el
@@ -1249,6 +1249,7 @@ values to copy the link to the clipboard and/or primary as well."  (interactive)
   (interactive)
   (link-hint--action-at-point :open))
 
+;;;###autoload
 (defun link-hint-copy-link-at-point ()
   "Copy the link with the highest priority at the point."
   (interactive)


### PR DESCRIPTION
Like the other interactive commands in link-hint, this one should be autoloaded.

This PR also fixes the `SPC x y` key binding in Spacemacs.