### PR TITLE
Support Markdown-derived modes

### DIFF
--- a/link-hint.el
+++ b/link-hint.el
@@ -495,7 +495,7 @@ Only search the range between just after the point and BOUND."
 (link-hint-define-type 'markdown-link
   :next #'link-hint--next-markdown-link
   :at-point-p #'link-hint--markdown-link-at-point-p
-  :vars '(markdown-mode)
+  :vars '(markdown-mode gfm-mode markdown-view-mode)
   :parser #'link-hint--parse-markdown-link
   :open #'link-hint--open-markdown-link
   :open-multiple t


### PR DESCRIPTION
This adds support for a couple of major modes derived from `markdown-mode`, i.e. `gfm-mode` (for GitHub-flavoured Markdown) and `markdown-view-mode` (readonly).