### PR TITLE
Check if epkg is available to prevent errors

### DIFF
--- a/link-hint.el
+++ b/link-hint.el
@@ -723,7 +723,7 @@ Only search the range between just after the point and BOUND."
 (defun link-hint--overlay-epkg-category (overlay)
   "If OVERLAY contains a category of epkg, return it."
   (let ((category (overlay-get overlay 'category)))
-    (when category
+    (when (and category (require 'epkg nil t))
       (catch 'category
         (dolist (type '(epkg-package
                         epkg-author


### PR DESCRIPTION
Fixes #182. It skips the entire loop if `epkg` is unavailable.