### PR TITLE
Add compilation-minor-mode

### DIFF
--- a/link-hint.el
+++ b/link-hint.el
@@ -794,7 +794,7 @@ Only search the range between just after the point and BOUND."
 (link-hint-define-type 'compilation-link
   :next #'link-hint--next-compilation-link
   :at-point-p #'link-hint--compilation-link-at-point-p
-  :vars '(compilation-mode)
+  :vars '(compilation-mode compilation-minor-mode)
   ;; no simple way to get message for copying
   :open #'compile-goto-error)
 


### PR DESCRIPTION
If you turn on `compilation-minor-mode` in modes such as `magit-process-buffer` and `vterm-mode`, you can jump to error locations quickly. It would be handy if link-hint supported this feature, and it becomes possible with this change.