### PR TITLE
added completion-list-candidate type

### DIFF
--- a/README.org
+++ b/README.org
@@ -27,6 +27,7 @@ Currently the following types of links are supported:
 - notmuch-hello links
 - Deadgrep matches
 - Other button links (e.g. WoMan links, ag mode, etc.)
+- Completion List candidates (better put it before /link-hint-file-link/ for *project.el*)
 
 Feel free to request support for any useful link type I may have missed. Also, if you think it would be beneficial to have a more specific link type split from a more generic link type, feel free to make an issue. For example, there may be some specific type of button you want to ignore or use in a custom command without affecting other buttons.
 

--- a/link-hint.el
+++ b/link-hint.el
@@ -941,6 +941,32 @@ Only search the range between just after the point and BOUND."
   :open #'widget-button-press
   :copy #'link-hint--copy-widget)
 
+;; ** Completion List candidate
+
+(defun link-hint--next-completion-list-candidate (&optional bound)
+  "Find the next completion list candidate location.
+Only search the range between just after the point and BOUND."
+  (next-completion 1)
+  (let ((bound (or bound (window-end)))
+        (point (point)))
+    (when (< point bound)
+      point)))
+
+(defun link-hint--open-completion-list-candidate (&rest _ignore)
+  "Select completion list candidate at point."
+  (choose-completion))
+
+(defun link-hint--completion-list-candidate-at-point-p ()
+  "Return the completion list candidate at the point or nil."
+  (get-text-property (point) 'completion--string))
+
+(link-hint-define-type 'completion-list-candidate
+  :next #'link-hint--next-completion-list-candidate
+  :vars '(completion-list-mode)
+  :open #'link-hint--open-completion-list-candidate
+  :at-point-p #'link-hint--completion-list-candidate-at-point-p
+  :copy #'kill-new)
+
 ;; * Avy/Action Helper Functions
 (defun link-hint--collect (start end type)
   "Between START and END in the current buffer, collect all links of TYPE."


### PR DESCRIPTION
2021-07-03  Valeriy Litkovskyy  <vlr.ltkvsk@protonmail.com>

    * link-hint.el (completion-list-candidate): Added
    completion-list-candidate type, that lets you select candidates of
    Completion-List mode in *Completions* buffer.

    * README.org (About): Mentioned completion-list-candidate type in
    readme.