### PR TITLE
Check invisible property of overlays for faster scanning of links

### DIFF
--- a/link-hint.el
+++ b/link-hint.el
@@ -215,27 +215,26 @@ range from between just after the START-BOUND and END-BOUND.
 
 This function takes into account invisible property of overlays.
 It returns the first match that has no non-nil invisible property set."
-  (when (setq start-bound (link-hint--visible-pos start-bound end-bound))
-    (let (first-non-match-pos
-          found)
-      (setq first-non-match-pos
-            (funcall (if value
-                         #'text-property-not-all
-                       #'text-property-any)
-                     start-bound end-bound property value))
-      (catch 'found
-        (while first-non-match-pos
-          (setq found (funcall (if value
-                                   #'text-property-any
-                                 #'text-property-not-all)
-                               first-non-match-pos end-bound property value))
-          (cond
-           ((and found (= found first-non-match-pos))
-            (throw 'found found))
-           (found
-            (setq first-non-match-pos (link-hint--visible-pos found end-bound)))
-           (t
-            (throw 'found nil))))))))
+  (let (first-non-match-pos
+        found)
+    (setq first-non-match-pos
+          (funcall (if value
+                       #'text-property-not-all
+                     #'text-property-any)
+                   start-bound end-bound property value))
+    (catch 'found
+      (while first-non-match-pos
+        (setq found (funcall (if value
+                                 #'text-property-any
+                               #'text-property-not-all)
+                             first-non-match-pos end-bound property value))
+        (cond
+         ((and found (= found first-non-match-pos))
+          (throw 'found found))
+         (found
+          (setq first-non-match-pos (link-hint--visible-pos found end-bound)))
+         (t
+          (throw 'found nil)))))))
 
 (defun link-hint--visible-pos (start &optional bound)
   "Return a visible pos on or after START before BOUND.


### PR DESCRIPTION
Fixes #206.

This PR extends `link-hint--find-property-with-value` function to check `invisible` property of overlays. Now link-hint is fast even in the situation in the referred issue. The downside is an added complexity of the function.

Please feel free to merge the PR or edit it.