### PR TITLE
Added support for notmuch with w3m as renderer

### DIFF
--- a/link-hint.el
+++ b/link-hint.el
@@ -867,7 +867,7 @@ Only search the range between just after the point and BOUND."
 (link-hint-define-type 'w3m-message-link
   :next #'link-hint--next-w3m-link
   :at-point-p #'link-hint--w3m-link-at-point-p
-  :vars '(gnus-article-mode)
+  :vars '(gnus-article-mode notmuch-show-mode)
   :open #'browse-url
   :copy #'kill-new)
 


### PR DESCRIPTION
Currently links aren't selectable when using w3m as a renderer in notmuch-show-mode.