### PR TITLE
Fix the regression of deadgrep support and a few other suggestions

### DIFF
--- a/link-hint.el
+++ b/link-hint.el
@@ -923,7 +923,7 @@ Only search the range between just after the point and BOUND."
 (defun link-hint--next-deadgrep-link (bound)
   "Find the next deadgrep link.
 Only search the range between just after the point and BOUND."
-  (link-hint--next-property-with-value 'face 'deadgrep-match-face bound))
+  (link-hint--next-property-with-value 'face 'deadgrep-meta-face bound))
 
 (defun link-hint--deadgrep-link-at-point-p ()
   "Return the link message at the point or nil."

--- a/link-hint.el
+++ b/link-hint.el
@@ -926,8 +926,11 @@ Only search the range between just after the point and BOUND."
   (link-hint--next-property-with-value 'face 'deadgrep-meta-face bound))
 
 (defun link-hint--deadgrep-link-at-point-p ()
-  "Return the link message at the point or nil."
-  (link-hint--property-text 'deadgrep-filename))
+  "Return the source location at the point."
+  (let ((filename (get-text-property (point) 'deadgrep-filename))
+        (line-number (get-text-property (point) 'deadgrep-line-number)))
+    (when (and filename line-number)
+      (format "%s:%s" filename line-number))))
 
 (link-hint-define-type 'deadgrep
   :next #'link-hint--next-deadgrep-link


### PR DESCRIPTION
Hi,

The deadgrep support seems to be broken. It no longer highlights matches, and this PR fixes the issue.

Also `link-hint--deadgrep-link-at-point-p` returned only a line number, which is somewhat hard to understand. I would propose a change to the `filename:line-number` format.

Finally, it would be nice if the links were opened in another window so I can browse many links using `link-hint`. What do you think? Is it better to leave it as it is? 