### PR TITLE
Don't use link-hint-shr-url for mastodon buffers

### DIFF
--- a/link-hint.el
+++ b/link-hint.el
@@ -441,7 +441,7 @@ Only search the range between just after the point and BOUND."
   :at-point-p #'link-hint--shr-url-at-point-p
   ;; would need a comprehensive list of all modes that use shr.el
   ;; :vars
-  :not-vars '(nov-mode)
+  :not-vars '(mastodon-mode nov-mode)
   :open #'browse-url
   :open-multiple t
   :copy #'kill-new)


### PR DESCRIPTION
See https://codeberg.org/martianh/mastodon.el/pulls/644 which define a button types for buttons for mastodon buffers however link-hint ends up opening the shr-url instead of more appropriate button.